### PR TITLE
Adjust server.py to follow PEP 8 guidelines

### DIFF
--- a/python/server.py
+++ b/python/server.py
@@ -38,9 +38,9 @@ hana = env.get_service(label='hana')
 
 @app.route('/')
 def hello_world():
-    output = '<strong>Python SecureStore! Instance ' +
-    str(os.getenv("CF_INSTANCE_INDEX", 0)) +
-    '</strong> Try these links.</br>\n'
+    output = '<strong>Python SecureStore! Instance ' + \
+             str(os.getenv("CF_INSTANCE_INDEX", 0)) + \
+             '</strong> Try these links.</br>\n'
     output += '<a href="/python/links">/python/links</a><br />\n'
     return output
 
@@ -56,9 +56,9 @@ def favicon():
 # Coming through the app-router
 @app.route('/python/links')
 def python_links():
-    output = '<strong>Python SecureStore! Instance ' +
-    str(os.getenv("CF_INSTANCE_INDEX", 0)) +
-    '</strong> Try these links.</br>\n'
+    output = '<strong>Python SecureStore! Instance ' + \
+             str(os.getenv("CF_INSTANCE_INDEX", 0)) + \
+             '</strong> Try these links.</br>\n'
     output += '<a href="/python/insert">/python/insert</a><br />\n'
     output += '<a href="/python/retrieve">/python/retrieve</a><br />\n'
     output += '<a href="/python/delete">/python/delete</a><br />\n'
@@ -124,8 +124,8 @@ def unauth_ss_insert():
     try:
         cursor.callproc("SYS.USER_SECURESTORE_INSERT",
                         ("TestStoreName", False, "TestKey", hex2store))
-        output += 'key TestKey with value ' + string2store + '=' + hex2store +
-        ' was inserted into store TestStoreName.' + '\n'
+        output += 'key TestKey with value ' + string2store + '=' + \
+                  hex2store + ' was inserted into store TestStoreName.\n'
     except:
         output += 'key TestKey likely already exists. Try deleting first.\n'
 
@@ -138,7 +138,7 @@ def unauth_ss_insert():
 
 @app.route('/python/retrieve')
 def unauth_ss_retrieve():
-    output = 'Python UnAuthorized SecureStore Retrieve. \n'
+    output = 'Python UnAuthorized SecureStore Retrieve.\n'
 
     schema = hana.credentials['schema']
     host = hana.credentials['host']
@@ -200,12 +200,12 @@ def unauth_ss_retrieve():
     import codecs
 
     if hexvalue[3] is None:
-        output += 'key TestKey does not exist in store TestStoreName. ' +
-        'Try inserting a value first.\n'
+        output += 'key TestKey does not exist in store TestStoreName. ' + \
+                  'Try inserting a value first.\n'
     else:
         retrieved = codecs.decode(hexvalue[3].hex(), "hex").decode()
-        output += 'key TestKey with value ' + retrieved +
-        ' was retrieved from store TestStoreName.\n'
+        output += 'key TestKey with value ' + retrieved + \
+                  ' was retrieved from store TestStoreName.\n'
 
     # Return the results
     return Response(output, mimetype='text/plain', status=200,)
@@ -267,7 +267,7 @@ def unauth_ss_delete():
     # Close the DB connection
     connection.close()
 
-    output += 'key TestKey was deleted from store TestStoreName.' + '\n'
+    output += 'key TestKey was deleted from store TestStoreName.\n'
 
     # Return the results
     return Response(output, mimetype='text/plain', status=200,)

--- a/python/server.py
+++ b/python/server.py
@@ -7,14 +7,14 @@ from flask import request
 from flask import Response
 
 from flask import send_from_directory
-#   
+
 import os
 import json
 from cfenv import AppEnv
+
+# from sap.cf_logging import flask_logging
 #
-#from sap.cf_logging import flask_logging
-#
-#https://help.sap.com/viewer/0eec0d68141541d1b07893a39944924e/2.0.03/en-US/d12c86af7cb442d1b9f8520e2aba7758.html
+# https://help.sap.com/viewer/0eec0d68141541d1b07893a39944924e/2.0.03/en-US/d12c86af7cb442d1b9f8520e2aba7758.html
 from hdbcli import dbapi
 
 
@@ -23,36 +23,47 @@ env = AppEnv()
 
 # Get port from environment variable or choose 9099 as local default
 # If you are testing locally (i.e. not with xs or cf deployments,
-# Be sure to pull all the python modules locally 
-#   with pip using XS_PYTHON unzipped to /tmp
+# Be sure to pull all the python modules locally
+# with pip using XS_PYTHON unzipped to /tmp
 # mkdir -p local
 # pip install -t local -r requirements.txt -f /tmp
 port = int(os.getenv("PORT", 9099))
 hana = env.get_service(label='hana')
 
-        
 # This module's Flask webserver will respond to these three routes (URL paths)
-# If there is no path then just return Hello World and this module's instance number
+# If there is no path then just return Hello World and
+# this module's instance number
 # Requests passed through the app-router will never hit this route.
+
+
 @app.route('/')
 def hello_world():
-    output = '<strong>Python SecureStore! Instance ' + str(os.getenv("CF_INSTANCE_INDEX", 0)) + '</strong> Try these links.</br>\n'
+    output = '<strong>Python SecureStore! Instance ' +
+    str(os.getenv("CF_INSTANCE_INDEX", 0)) +
+    '</strong> Try these links.</br>\n'
     output += '<a href="/python/links">/python/links</a><br />\n'
     return output
-    
+
+
 # Satisfy browser requests for favicon.ico so that don't return 404
 @app.route('/favicon.ico')
 def favicon():
-    return send_from_directory(os.path.join(app.root_path, 'static'),'favicon.ico', mimetype='image/vnd.microsoft.icon')
+    return send_from_directory(os.path.join(app.root_path, 'static'),
+                               'favicon.ico',
+                               mimetype='image/vnd.microsoft.icon')
+
 
 # Coming through the app-router
 @app.route('/python/links')
 def python_links():
-    output = '<strong>Python SecureStore! Instance ' + str(os.getenv("CF_INSTANCE_INDEX", 0)) + '</strong> Try these links.</br>\n'
+    output = '<strong>Python SecureStore! Instance ' +
+    str(os.getenv("CF_INSTANCE_INDEX", 0)) +
+    '</strong> Try these links.</br>\n'
     output += '<a href="/python/insert">/python/insert</a><br />\n'
     output += '<a href="/python/retrieve">/python/retrieve</a><br />\n'
     output += '<a href="/python/delete">/python/delete</a><br />\n'
     return output
+
 
 @app.route('/python/insert')
 def unauth_ss_insert():
@@ -64,19 +75,21 @@ def unauth_ss_insert():
     user = hana.credentials['user']
     password = hana.credentials['password']
 
-    # The certificate will available for HANA service instances that require an encrypted connection
-    # Note: This was tested to work with python hdbcli-2.3.112 tar.gz package not hdbcli-2.3.14 provided in XS_PYTHON00_0-70003433.ZIP  
+    # The certificate will available for HANA service instances that
+    # require an encrypted connection
+    # Note: This was tested to work with python hdbcli-2.3.112 tar.gz package
+    # not hdbcli-2.3.14 provided in XS_PYTHON00_0-70003433.ZIP
     if 'certificate' in hana.credentials:
         haascert = hana.credentials['certificate']
-    
+
     output += 'schema: ' + schema + '\n'
     output += 'host: ' + host + '\n'
     output += 'port: ' + port + '\n'
     output += 'user: ' + user + '\n'
     output += 'pass: ' + password + '\n'
 
-#    # Connect to the python HANA DB driver using the connection info
-# User for HANA as a Service instances
+    # Connect to the python HANA DB driver using the connection info
+    # User for HANA as a Service instances
     if 'certificate' in hana.credentials:
         connection = dbapi.connect(
             address=host,
@@ -97,12 +110,11 @@ def unauth_ss_insert():
             password=password,
             currentSchema=schema
         )
- 
 
-#    # Prep a cursor for SQL execution
+    # Prep a cursor for SQL execution
     cursor = connection.cursor()
 
-#    # Form an SQL statement to retrieve some data
+    # Form an SQL statement to retrieve some data
 
     string2store = 'Whatever!'
 
@@ -110,16 +122,19 @@ def unauth_ss_insert():
     hex2store = (codecs.encode(str.encode(string2store), "hex")).decode()
 
     try:
-        cursor.callproc("SYS.USER_SECURESTORE_INSERT", ("TestStoreName", False, "TestKey", hex2store))
-        output += 'key TestKey with value ' + string2store + '=' + hex2store + ' was inserted into store TestStoreName.' + '\n'
+        cursor.callproc("SYS.USER_SECURESTORE_INSERT",
+                        ("TestStoreName", False, "TestKey", hex2store))
+        output += 'key TestKey with value ' + string2store + '=' + hex2store +
+        ' was inserted into store TestStoreName.' + '\n'
     except:
-        output += 'key TestKey likely already exists. Try deleting first.' + '\n'
+        output += 'key TestKey likely already exists. Try deleting first.\n'
 
-#    # Close the DB connection
+    # Close the DB connection
     connection.close()
 
     # Return the results
-    return Response(output, mimetype='text/plain' , status=200,)
+    return Response(output, mimetype='text/plain', status=200,)
+
 
 @app.route('/python/retrieve')
 def unauth_ss_retrieve():
@@ -131,19 +146,21 @@ def unauth_ss_retrieve():
     user = hana.credentials['user']
     password = hana.credentials['password']
 
-    # The certificate will available for HANA service instances that require an encrypted connection
-    # Note: This was tested to work with python hdbcli-2.3.112 tar.gz package not hdbcli-2.3.14 provided in XS_PYTHON00_0-70003433.ZIP  
+    # The certificate will available for HANA service instances
+    # that require an encrypted connection
+    # Note: This was tested to work with python hdbcli-2.3.112 tar.gz package
+    # not hdbcli-2.3.14 provided in XS_PYTHON00_0-70003433.ZIP
     if 'certificate' in hana.credentials:
         haascert = hana.credentials['certificate']
-    
+
     output += 'schema: ' + schema + '\n'
     output += 'host: ' + host + '\n'
     output += 'port: ' + port + '\n'
     output += 'user: ' + user + '\n'
     output += 'pass: ' + password + '\n'
 
-#    # Connect to the python HANA DB driver using the connection info
-# User for HANA as a Service instances
+    # Connect to the python HANA DB driver using the connection info
+    # User for HANA as a Service instances
     if 'certificate' in hana.credentials:
         connection = dbapi.connect(
             address=host,
@@ -164,31 +181,35 @@ def unauth_ss_retrieve():
             password=password,
             currentSchema=schema
         )
- 
 
-#    # Prep a cursor for SQL execution
+    # Prep a cursor for SQL execution
     cursor = connection.cursor()
 
-#    # Form an SQL statement to retrieve some data
+    # Form an SQL statement to retrieve some data
 
-#https://blogs.sap.com/2017/07/26/sap-hana-2.0-sps02-new-feature-updated-python-driver/
+    # https://blogs.sap.com/2017/07/26/sap-hana-2.0-sps02-new-feature-updated-python-driver/
 
-    #cursor.execute('call SYS.USER_SECURESTORE_RETRIEVE (\'TestStoreName\', False, \'TestKey\', ?)')
-    hexvalue = cursor.callproc("SYS.USER_SECURESTORE_RETRIEVE", ("TestStoreName", False, "TestKey", None))
+    # cursor.execute('call SYS.USER_SECURESTORE_RETRIEVE (\'TestStoreName\',
+	#                False, \'TestKey\', ?)')
+    hexvalue = cursor.callproc("SYS.USER_SECURESTORE_RETRIEVE",
+                               ("TestStoreName", False, "TestKey", None))
 
-#    # Close the DB connection
+    # Close the DB connection
     connection.close()
 
     import codecs
 
     if hexvalue[3] is None:
-        output += 'key TestKey does not exist in store TestStoreName.  Try inserting a value first.' + '\n'
+        output += 'key TestKey does not exist in store TestStoreName. ' +
+        'Try inserting a value first.\n'
     else:
         retrieved = codecs.decode(hexvalue[3].hex(), "hex").decode()
-        output += 'key TestKey with value ' + retrieved + ' was retrieved from store TestStoreName.' + '\n'
+        output += 'key TestKey with value ' + retrieved +
+        ' was retrieved from store TestStoreName.\n'
 
     # Return the results
-    return Response(output, mimetype='text/plain' , status=200,)
+    return Response(output, mimetype='text/plain', status=200,)
+
 
 @app.route('/python/delete')
 def unauth_ss_delete():
@@ -200,19 +221,21 @@ def unauth_ss_delete():
     user = hana.credentials['user']
     password = hana.credentials['password']
 
-    # The certificate will available for HANA service instances that require an encrypted connection
-    # Note: This was tested to work with python hdbcli-2.3.112 tar.gz package not hdbcli-2.3.14 provided in XS_PYTHON00_0-70003433.ZIP  
+    # The certificate will available for HANA service instances
+    # that require an encrypted connection
+    # Note: This was tested to work with python hdbcli-2.3.112 tar.gz package
+    # not hdbcli-2.3.14 provided in XS_PYTHON00_0-70003433.ZIP
     if 'certificate' in hana.credentials:
         haascert = hana.credentials['certificate']
-    
+
     output += 'schema: ' + schema + '\n'
     output += 'host: ' + host + '\n'
     output += 'port: ' + port + '\n'
     output += 'user: ' + user + '\n'
     output += 'pass: ' + password + '\n'
 
-#    # Connect to the python HANA DB driver using the connection info
-# User for HANA as a Service instances
+    # Connect to the python HANA DB driver using the connection info
+    # User for HANA as a Service instances
     if 'certificate' in hana.credentials:
         connection = dbapi.connect(
             address=host,
@@ -233,28 +256,26 @@ def unauth_ss_delete():
             password=password,
             currentSchema=schema
         )
- 
 
-#    # Prep a cursor for SQL execution
+    # Prep a cursor for SQL execution
     cursor = connection.cursor()
 
-#    # Form an SQL statement
-    cursor.callproc("SYS.USER_SECURESTORE_DELETE", ("TestStoreName", False, "TestKey"))
+    # Form an SQL statement
+    cursor.callproc("SYS.USER_SECURESTORE_DELETE",
+                    ("TestStoreName", False, "TestKey"))
 
-#    # Close the DB connection
+    # Close the DB connection
     connection.close()
-    
+
     output += 'key TestKey was deleted from store TestStoreName.' + '\n'
-    
+
     # Return the results
-    return Response(output, mimetype='text/plain' , status=200,)
+    return Response(output, mimetype='text/plain', status=200,)
 
 
 if __name__ == '__main__':
     # Run the app, listening on all IPs with our chosen port number
-    # Use this for production 
-    #app.run(host='0.0.0.0', port=port)
-    # Use this for debugging 
+    # Use this for production
+    # app.run(host='0.0.0.0', port=port)
+    # Use this for debugging
     app.run(debug=True, host='0.0.0.0', port=port)
-
-

--- a/python/server.py
+++ b/python/server.py
@@ -190,7 +190,7 @@ def unauth_ss_retrieve():
     # https://blogs.sap.com/2017/07/26/sap-hana-2.0-sps02-new-feature-updated-python-driver/
 
     # cursor.execute('call SYS.USER_SECURESTORE_RETRIEVE (\'TestStoreName\',
-	#                False, \'TestKey\', ?)')
+    # False, \'TestKey\', ?)')
     hexvalue = cursor.callproc("SYS.USER_SECURESTORE_RETRIEVE",
                                ("TestStoreName", False, "TestKey", None))
 


### PR DESCRIPTION
While [PEP 8](https://www.python.org/dev/peps/pep-0008/) is a series of guidelines, and not necessarily a requirement, there are a lot of automated build tools that enforce it. The reason for this is that PEP 8 provides a clear standard for even more readable code.

There were also a few odd things I cleaned up, like double comments (`#    #  comment here`) and some unnecessary string concatenation, like adding a newline onto the end of a string instead of including it in the string.

(this pull request does not break or change any code, it only makes it more readable)